### PR TITLE
Added missing "rollup" package to the peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "type": "git",
     "url": "https://github.com/mjeanroy/rollup-plugin-license"
   },
+  "peerDependencies": {
+    "rollup": "1.1.0"
+  },
   "dependencies": {
     "commenting": "1.0.5",
     "lodash": "4.17.11",


### PR DESCRIPTION
The `rollup` package was missing from the `peerDependencies` section of the `package.json` file, however, it should be there to indicate the dependency and versions compatibility.

@mjeanroy you should probably update the version specifier to be more relaxed, it should allow minimal version of the Rollup supported by the `rollup-plugin-license`.