### PR TITLE
fix(license-plugin): Add support for leading NULL character

### DIFF
--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -150,7 +150,12 @@ module.exports = class LicensePlugin {
    * @return {void}
    */
   scanDependency(id) {
-    this.debug(`scanning ${id}`);
+    if (id.startsWith('\0')) {
+      id = id.replace(/^\0/, '');
+      this.debug(`scanning internal module ${id}`);
+    } else {
+      this.debug(`scanning ${id}`);
+    }
 
     // Look for the `package.json` file
     let dir = path.parse(id).dir;

--- a/test/license-plugin.spec.js
+++ b/test/license-plugin.spec.js
@@ -183,6 +183,35 @@ describe('LicensePlugin', () => {
     });
   });
 
+  it('should try to load pkg without leading NULL character ', () => {
+    const plugin = new LicensePlugin();
+    const fakePackage = path.join(__dirname, 'fixtures', 'fake-package');
+    const idNoNull = path.join(fakePackage, 'src', 'index.js');
+    const id = '\0' + idNoNull;
+    const pkg = require(path.join(fakePackage, 'package.json'));
+
+    plugin.scanDependency(id);
+
+    expect(plugin._dependencies).toEqual({
+      'fake-package': {
+        name: 'fake-package',
+        version: '1.0.0',
+        description: 'Fake package used in unit tests',
+        license: 'MIT',
+        private: true,
+        author: {
+          name: 'Mickael Jeanroy',
+          email: 'mickael.jeanroy@gmail.com',
+        },
+      },
+    });
+
+    expect(plugin._cache).toEqual({
+      [path.join(__dirname, 'fixtures', 'fake-package', 'src')]: pkg,
+      [path.join(__dirname, 'fixtures', 'fake-package')]: pkg,
+    });
+  });
+
   it('should load pkg and use the cache if available', () => {
     const plugin = new LicensePlugin();
     const fakePackage = path.join(__dirname, 'fixtures', 'fake-package');


### PR DESCRIPTION
NULL characters are typically added by internal or virtual modules, but it sometimes corresponds to
a real file/module. The plugin should try to access the real `package.json`, if any

fix #1

> PS: Sorry for the delay, I was sick the last few days. Here it is, tests included.
>
> :beers: cheers !