### PR TITLE
fix: exclude tree shaken modules from dependencies to scan

### DIFF
--- a/src/index-rollup-stable.js
+++ b/src/index-rollup-stable.js
@@ -24,6 +24,7 @@
 
 'use strict';
 
+const _ = require('lodash');
 const LicensePlugin = require('./license-plugin.js');
 
 module.exports = (options = {}) => {
@@ -37,17 +38,6 @@ module.exports = (options = {}) => {
     name: plugin.name,
 
     /**
-     * Function called by rollup when a JS file is loaded: it is used to scan
-     * third-party dependencies.
-     *
-     * @param {string} id JS file path.
-     * @return {void}
-     */
-    load(id) {
-      plugin.scanDependency(id);
-    },
-
-    /**
      * Function called by rollup when the final bundle is generated: it is used
      * to prepend the banner file on the generated bundle.
      *
@@ -57,6 +47,15 @@ module.exports = (options = {}) => {
      * @return {void}
      */
     renderChunk(code, chunk, outputOptions = {}) {
+      plugin.scanDependencies(
+          _.chain(chunk.modules)
+              .toPairs()
+              .reject((mod) => mod[1].isAsset)
+              .filter((mod) => mod[1].renderedLength > 0)
+              .map((mod) => mod[0])
+              .value()
+      );
+
       return plugin.prependBanner(code, outputOptions.sourcemap !== false);
     },
 

--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -153,9 +153,9 @@ module.exports = class LicensePlugin {
     if (id.startsWith('\0')) {
       id = id.replace(/^\0/, '');
       this.debug(`scanning internal module ${id}`);
-    } else {
-      this.debug(`scanning ${id}`);
     }
+
+    this.debug(`scanning ${id}`);
 
     // Look for the `package.json` file
     let dir = path.parse(id).dir;
@@ -199,6 +199,20 @@ module.exports = class LicensePlugin {
     // Update the cache
     _.forEach(scannedDirs, (scannedDir) => {
       this._cache[scannedDir] = pkg;
+    });
+  }
+
+  /**
+   * Hook triggered by `rollup` to load code from given path file.
+   *
+   * @param {Object} dependencies List of modules included in the final bundle.
+   * @return {void}
+   */
+  scanDependencies(dependencies) {
+    this.debug(`Scanning: ${dependencies}`);
+
+    _.forEach(dependencies, (dependency) => {
+      this.scanDependency(dependency);
     });
   }
 

--- a/test/license-plugin.spec.js
+++ b/test/license-plugin.spec.js
@@ -130,6 +130,35 @@ describe('LicensePlugin', () => {
     });
   });
 
+  it('should load pkg dependencies', () => {
+    const plugin = new LicensePlugin();
+    const modules = [
+      path.join(__dirname, 'fixtures', 'fake-package', 'src', 'index.js'),
+    ];
+
+    spyOn(plugin, 'scanDependency').and.callThrough();
+    spyOn(plugin, 'addDependency').and.callThrough();
+
+    const result = plugin.scanDependencies(modules);
+
+    expect(result).not.toBeDefined();
+    expect(plugin.scanDependency).toHaveBeenCalledWith(modules[0]);
+    expect(plugin.addDependency).toHaveBeenCalled();
+    expect(plugin._dependencies).toEqual({
+      'fake-package': {
+        name: 'fake-package',
+        version: '1.0.0',
+        description: 'Fake package used in unit tests',
+        license: 'MIT',
+        private: true,
+        author: {
+          name: 'Mickael Jeanroy',
+          email: 'mickael.jeanroy@gmail.com',
+        },
+      },
+    });
+  });
+
   it('should load pkg and stop on cwd', () => {
     const plugin = new LicensePlugin();
     const id = path.join(__dirname, '..', 'src', 'index.js');


### PR DESCRIPTION
Fix #380 