### PR TITLE
fix: use `nocase: true` for `licenseFile`

### DIFF
--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -186,7 +186,7 @@ class LicensePlugin {
           pkg = pkgJson;
 
           // Read license file, if it exists.
-          const licenseFile = glob.sync(path.join(dir, 'LICENSE*'))[0];
+          const licenseFile = glob.sync(path.join(dir, 'LICENSE*'), {nocase: true})[0];
           if (licenseFile) {
             pkg.licenseText = fs.readFileSync(licenseFile, 'utf-8');
           }


### PR DESCRIPTION
Some dependencies have their LICENSE files named `license`. The glob pattern doesn't pick up on it unless `nocase` is `true`.