### PR TITLE
Fix infinite loop

### DIFF
--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -151,7 +151,7 @@ class LicensePlugin {
 
     const scannedDirs = [];
 
-    while (dir && dir !== this._cwd) {
+    while (dir && dir !== this._cwd && !scannedDirs.includes(dir)) {
       // Try the cache.
       if (_.has(this._cache, dir)) {
         pkg = this._cache[dir];

--- a/test/license-plugin.spec.js
+++ b/test/license-plugin.spec.js
@@ -312,6 +312,12 @@ describe('LicensePlugin', () => {
       expect(plugin._dependencies).toEqual({});
       expect(existsSync).not.toHaveBeenCalled();
     });
+
+    it('should not run into an infinite loop for relative paths starting with a slash', () => {
+      const id = '/abc/efg';
+
+      plugin.scanDependency(id);
+    });
   });
 
   describe('when adding dependencies', () => {


### PR DESCRIPTION
# Problem
When a dependency id starts with a slash and is outside the cwd an infinite loop occures. This happens because the `scanDependency` method loops through the direcories (always going to the parent) until it reaches "\\" (or "/" in case of unix). At this point the next step would be "\\.." which normalized equals "\\" and that is where the infinite loop beginns. Having a dependency id which is a relative path starting with a slash might be a bit weired but sadly it is something Vite does.

# Solution
Since the `scannedDirs` are already tracked the easiest solution I came up with is to check in the `while` condition if the current `dir` was already scanned.

# Test
The test I wrote is a bit weired, I tried using jasmine async tests but they didnt seem to work / they would not timeout and behaved exactly as the current test setup does. Not sure if its because its run using gulp? With the test setup this way the tests would run indefinitely in case of the infinite loop (there seems to be no jasmin/gulp timeout at all???). Would be nice if the test would fail after 1-5 secs but so far nothing I tried made the test fail, ideas welcome :)

