### PR TITLE
Add alwaysInclude &  filters options

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,32 @@ license({
 })
 ```
 
+
+You can also add or remove dependencies using a `filter` function:
+
+```javascript
+license({
+  thirdParty: {
+    output: path.join(__dirname, 'dist', 'dependencies.txt'),
+    filter: (deps) => deps.filter((dep) => !dep.name.include('mycorp'),
+  },
+})
+```
+
+Or add packages that must always appear in the output, but would otherwise be omitted:
+
+
+```javascript
+license({
+  thirdParty: {
+    output: path.join(__dirname, 'dist', 'dependencies.txt'),
+    alwaysInclude: [ './node_modules/tailwindcss/package.json' ],
+    }
+  },
+})
+
+`alwaysInclude` may be either an array or a function that returns an array.
+
 ## License Checks
 
 Starting with version 0.13, it is possible to ensure that dependencies does not violate any license restriction.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "gulp lint",
     "clean": "gulp clean",
     "build": "gulp build",
+    "prepare": "gulp build",
     "watch": "gulp watch",
     "test": "gulp test",
     "tdd": "gulp tdd",

--- a/src/license-plugin-option.js
+++ b/src/license-plugin-option.js
@@ -64,6 +64,11 @@ const SCHEMA = {
       includePrivate: validators.boolean(),
       includeSelf: validators.boolean(),
       multipleVersions: validators.boolean(),
+      alwaysInclude: [
+        validators.func(),
+        validators.array(),
+      ],
+      filter: validators.func(),
 
       allow: [
         validators.string(),

--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -323,9 +323,15 @@ class LicensePlugin {
       return;
     }
 
+    const { alwaysInclude } = thirdParty;
+    if (alwaysInclude) {
+      const entries = _.isFunction(alwaysInclude) ? alwaysInclude() : alwaysInclude;
+      entries.forEach((entryPath) => this.scanDependency(entryPath));
+    }
+
     const includePrivate = thirdParty.includePrivate || false;
     const includeSelf = thirdParty.includeSelf || false;
-    const outputDependencies = [...this._dependencies.values()].filter((dependency) => {
+    let outputDependencies = [...this._dependencies.values()].filter((dependency) => {
       if (dependency.self && includeSelf) {
         return true;
       }
@@ -342,7 +348,11 @@ class LicensePlugin {
       return;
     }
 
-    const { allow, output } = thirdParty;
+    const { allow, output, filter } = thirdParty;
+
+    if (filter) {
+      outputDependencies = filter(outputDependencies);
+    }
 
     if (allow) {
       this._scanLicenseViolations(outputDependencies, allow);


### PR DESCRIPTION
Resolves #1092 

Adds a `alwaysInclude` option that takes an array of packages (or a function returning an array) to always include in the third party dependency set.

```javascript
license({
  thirdParty: {
    output: path.join(__dirname, 'dist', 'dependencies.txt'),
    alwaysInclude: [ './node_modules/tailwindcss/package.json' ],
    }
  },
})
```

Adds a `filter` option that lets you add a function to filter out _(or potentially add more, or merge sets together, which is the use case i was solving for)_ arbitrary dependencies.

```javascript
license({
  thirdParty: {
    output: path.join(__dirname, 'dist', 'dependencies.txt'),
    filter: (deps) => deps.filter((dep) => !dep.name.include('mycorp'),
  },
})
```
