### PR TITLE
enh: allow multiple versions of dependencies

### DIFF
--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -280,7 +280,9 @@ class LicensePlugin {
    * @return {void}
    */
   addDependency(pkg) {
-    const name = pkg.name;
+    const name = (this._options.thirdParty && this._options.thirdParty.multipleVersions) ?
+      `${pkg.name}@${pkg.version}` :
+      pkg.name;
     if (!name) {
       this.warn('Trying to add dependency without any name, skipping it.');
     } else if (!_.has(this._dependencies, name)) {

--- a/test/license-plugin.spec.js
+++ b/test/license-plugin.spec.js
@@ -133,6 +133,23 @@ describe('LicensePlugin', () => {
       });
     });
 
+    it('should load pkg with version in key when multipleVersions option is truthy', () => {
+      const id = path.join(__dirname, 'fixtures', 'fake-package-1', 'src', 'index.js');
+
+      plugin._options = {
+        thirdParty: {
+          multipleVersions: true,
+        },
+      };
+
+      plugin.scanDependency(id);
+
+      expect(addDependency).toHaveBeenCalled();
+      expect(plugin._dependencies).toEqual({
+        [`${fakePackage.name}@${fakePackage.version}`]: fakePackage,
+      });
+    });
+
     it('should load pkg and going up directories until a package name is found', () => {
       const id = path.join(__dirname, 'fixtures', 'fake-package-5', 'esm', 'index.js');
 


### PR DESCRIPTION
Currently the plugin is keeping a list of dependencies keyed by the packages' name. This is limited for the case when transitive dependencies may force multiple versions of a package to be bundled. If, in such case, the packages have different licenses the report may be misleading.