### PR TITLE
declare Rollup 4 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest, macos-latest ]
-        node: [ 14, 16, 18, 19, 20 ]
+        node: [ 18, 19, 20 ]
     steps:
       - uses: actions/checkout@v3.6.0
       - uses: actions/setup-node@v3.8.1

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "gulp test",
     "tdd": "gulp tdd",
     "changelog": "gulp changelog",
+    "prepare": "npm run build",
     "release": "gulp release:minor",
     "release:patch": "gulp release:patch",
     "release:minor": "gulp release:minor",
@@ -33,7 +34,7 @@
     "url": "https://github.com/mjeanroy/rollup-plugin-license"
   },
   "peerDependencies": {
-    "rollup": "^1.0.0 || ^2.0.0 || ^3.0.0"
+    "rollup": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "commenting": "~1.1.0",
@@ -69,7 +70,7 @@
     "jasmine-core": "3.10.1",
     "prettier": "3.0.3",
     "rimraf": "5.0.5",
-    "rollup": "3.29.4",
+    "rollup": "4.0.2",
     "rollup-plugin-prettier": "4.1.0",
     "rollup-plugin-strip-banner": "3.1.0",
     "tmp": "0.2.1",


### PR DESCRIPTION
There are no breaking changes in Rollup 4 that should affect this plugin. This will extend the peerDependencies version range.
I added a `prepare` script so that I can install from my fork.