### PR TITLE
feat: drop glob usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "commenting": "~1.1.0",
-    "glob": "~7.2.0",
+    "fdir": "6.1.1",
     "lodash": "~4.17.21",
     "magic-string": "~0.30.0",
     "mkdirp": "~3.0.0",


### PR DESCRIPTION
Removes `glob` and uses fdir instead with a basic directory traversal (no globs).

Reduces the complexity of the file reading logic and the install size (~3MB glob vs 56KB fdir).