### PR TITLE
feat: drop mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "glob": "~7.2.0",
     "lodash": "~4.17.21",
     "magic-string": "~0.30.0",
-    "mkdirp": "~3.0.0",
     "moment": "~2.30.1",
     "package-name-regex": "~2.0.6",
     "spdx-expression-validate": "~2.0.0",

--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -24,7 +24,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import { mkdirp } from 'mkdirp';
 import _ from 'lodash';
 import moment from 'moment';
 import MagicString from 'magic-string';
@@ -588,7 +587,7 @@ class LicensePlugin {
     this.debug(`use encoding: ${encoding}`);
 
     // Create directory if it does not already exist.
-    mkdirp.sync(path.parse(file).dir);
+    fs.mkdirSync(path.parse(file).dir, { recursive: true });
 
     fs.writeFileSync(file, (text || '').trim(), {
       encoding,


### PR DESCRIPTION
Removes `mkdirp` and uses the built in `recursive` flag node provides (since 10.x).