### PR TITLE
chore: unpin fdir

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "commenting": "~1.1.0",
-    "fdir": "6.4.3",
+    "fdir": "^6.4.3",
     "lodash": "~4.17.21",
     "magic-string": "~0.30.0",
     "moment": "~2.30.1",


### PR DESCRIPTION
I noticed I have multiple versions of `fdir` in my project as it can't be deduped due to the pinning here. This appears to be the only dependency that is pinned to an exact version, so I was wondering if it's necessary or can be changed